### PR TITLE
Fix: Thumbnail bar scroll position on window resize

### DIFF
--- a/src/components/ThumbnailBar.tsx
+++ b/src/components/ThumbnailBar.tsx
@@ -88,6 +88,7 @@ const ThumbnailItem: React.FC<ThumbnailItemProps> = memo(({ image, index, isActi
 const ThumbnailBar: React.FC = () => {
   const { folder, currentImage, navigateToImage } = useAppStore();
   const containerRef = useRef<HTMLDivElement>(null);
+  const thumbnailBarRef = useRef<HTMLDivElement>(null);
   const [isHovered, setIsHovered] = useState(false);
 
   const handleThumbnailClick = useCallback((index: number) => {
@@ -113,7 +114,7 @@ const ThumbnailBar: React.FC = () => {
     }
   }, [currentImage.index, folder.images.length, navigateToImage]);
 
-  useEffect(() => {
+  const scrollToActiveItem = useCallback(() => {
     if (containerRef.current && currentImage.index !== -1) {
       const activeItem = containerRef.current.querySelector('.thumbnail-item.active') as HTMLElement;
       if (activeItem) {
@@ -132,6 +133,25 @@ const ThumbnailBar: React.FC = () => {
     }
   }, [currentImage.index]);
 
+  useEffect(() => {
+    scrollToActiveItem();
+  }, [scrollToActiveItem]);
+
+  useEffect(() => {
+    const thumbnailBar = thumbnailBarRef.current;
+    if (!thumbnailBar) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      scrollToActiveItem();
+    });
+
+    resizeObserver.observe(thumbnailBar);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [scrollToActiveItem]);
+
   const imageInfo = useMemo(() => {
     if (!currentImage.path || !folder.images[currentImage.index]) {
       return null;
@@ -146,6 +166,7 @@ const ThumbnailBar: React.FC = () => {
 
   return (
     <div
+      ref={thumbnailBarRef}
       className={`thumbnail-bar ${isHovered ? 'hovered' : ''}`}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}


### PR DESCRIPTION
## Summary
- Fixed thumbnail bar scroll misalignment on window resize
- Current image now always stays centered after window size changes

## Problem
When the window was resized (maximize, minimize, or manual resize), the thumbnail bar's scroll position would become misaligned, causing the current image to shift away from the center.

## Solution
- Refactored scroll logic into `scrollToActiveItem` callback function
- Added `ResizeObserver` to monitor the thumbnail bar element's size changes
- Scroll position is now recalculated automatically whenever the bar is resized

## Technical Details
The fix uses `ResizeObserver` on the `.thumbnail-bar` element (instead of the inner container) because:
- The outer element reliably changes size when the window is resized
- More efficient than listening to global `window.resize` events
- Provides better performance for this specific use case

## Testing
- ✅ All 137 existing tests pass
- ✅ Type checking passes
- ✅ Manually verified: maximize/minimize/resize operations now keep current image centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)