### PR TITLE
fix: remove unused code and imports in backend tests

### DIFF
--- a/src-tauri/src/commands/cache.rs
+++ b/src-tauri/src/commands/cache.rs
@@ -221,7 +221,6 @@ pub async fn get_cache_stats() -> Result<HashMap<String, u32>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[tokio::test]
     async fn test_get_cached_thumbnail_returns_ok() {

--- a/src-tauri/src/test_utils.rs
+++ b/src-tauri/src/test_utils.rs
@@ -83,19 +83,3 @@ pub fn create_fake_image(dir: &Path, filename: &str) -> PathBuf {
     fs::write(&file_path, b"This is not an image").expect("Failed to create fake image");
     file_path
 }
-
-/// Sets up a test environment variable
-pub fn setup_test_env_var(key: &str, value: &str) -> String {
-    let original = std::env::var(key).unwrap_or_default();
-    std::env::set_var(key, value);
-    original
-}
-
-/// Restores an environment variable
-pub fn restore_env_var(key: &str, original: &str) {
-    if original.is_empty() {
-        std::env::remove_var(key);
-    } else {
-        std::env::set_var(key, original);
-    }
-}


### PR DESCRIPTION
## Summary
- Remove unused imports from cache tests
- Remove unused test utility functions

## Changes
- `src-tauri/src/commands/cache.rs`: Removed unused `SystemTime` and `UNIX_EPOCH` imports
- `src-tauri/src/test_utils.rs`: Removed unused `setup_test_env_var` and `restore_env_var` functions

## Test Results
All 62 backend tests pass with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)