### PR TITLE
feat: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,6 +7,7 @@ on:
       - completed
 
 permissions:
+  actions: read
   pull-requests: write
   contents: write
 
@@ -45,6 +46,7 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          pr-number: ${{ steps.pr.outputs.number }}
 
       - name: Determine if auto-merge is allowed
         id: auto-merge-decision
@@ -55,6 +57,10 @@ jobs:
           echo "Update type: $UPDATE_TYPE"
           echo "Dependency type: $DEPENDENCY_TYPE"
 
+          # Auto-merge policy:
+          # - Production dependencies: Only patch updates (conservative approach for stability)
+          # - Development dependencies: Patch and minor updates (less risk for dev tools)
+          # - Indirect dependencies: Treated like dev dependencies (patch and minor updates)
           SHOULD_MERGE=false
 
           # Production dependencies: only patch updates
@@ -65,30 +71,23 @@ jobs:
             else
               echo "✗ Production dependency $UPDATE_TYPE - requires manual review"
             fi
-          fi
-
           # Development dependencies: patch and minor updates
-          if [[ "$DEPENDENCY_TYPE" == "direct:development" ]]; then
+          elif [[ "$DEPENDENCY_TYPE" == "direct:development" ]]; then
             if [[ "$UPDATE_TYPE" == "version-update:semver-patch" ]] || [[ "$UPDATE_TYPE" == "version-update:semver-minor" ]]; then
               SHOULD_MERGE=true
               echo "✓ Development dependency $UPDATE_TYPE - will auto-merge"
             else
               echo "✗ Development dependency $UPDATE_TYPE - requires manual review"
             fi
-          fi
-
           # Indirect dependencies: patch and minor updates (treat like dev dependencies)
-          if [[ "$DEPENDENCY_TYPE" == "indirect" ]]; then
+          elif [[ "$DEPENDENCY_TYPE" == "indirect" ]]; then
             if [[ "$UPDATE_TYPE" == "version-update:semver-patch" ]] || [[ "$UPDATE_TYPE" == "version-update:semver-minor" ]]; then
               SHOULD_MERGE=true
               echo "✓ Indirect dependency $UPDATE_TYPE - will auto-merge"
             else
               echo "✗ Indirect dependency $UPDATE_TYPE - requires manual review"
             fi
-          fi
-
-          # Log unhandled dependency types
-          if [[ "$DEPENDENCY_TYPE" != "direct:production" && "$DEPENDENCY_TYPE" != "direct:development" && "$DEPENDENCY_TYPE" != "indirect" ]]; then
+          else
             echo "⚠️ Unhandled dependency type: $DEPENDENCY_TYPE - will not auto-merge"
           fi
 


### PR DESCRIPTION
## Summary

Dependabotのプルリクエストを自動的にマージするGitHub Actionsワークフローを追加しました。

## 機能概要

### 自動マージルール

**本番依存関係 (dependencies)**
- ✅ パッチ更新のみ自動マージ (例: 1.2.3 → 1.2.4)
- ⚠️ マイナー・メジャー更新は手動レビュー

**開発依存関係 (devDependencies)**
- ✅ パッチ更新を自動マージ (例: 1.2.3 → 1.2.4)
- ✅ マイナー更新を自動マージ (例: 1.2.0 → 1.3.0)
- ⚠️ メジャー更新は手動レビュー

### 対象パッケージエコシステム

- npm (フロントエンド依存関係)
- cargo (Rust/バックエンド依存関係)
- github-actions (ワークフロー依存関係)

### 安全機能

- CIワークフロー (frontend-tests + backend-tests) の成功を必須確認
- Dependabotが作成したPRのみ対象
- 手動レビューが必要なPRにはコメントで通知

## ワークフローの動作

1. DependabotがPRを作成
2. CIワークフローが実行 (type-check, lint, format, tests)
3. CI成功後、このワークフローが起動
4. 更新タイプと依存関係タイプを判定
5. ルールに合致すれば自動承認→自動マージ
6. ルールに合致しなければコメント追加（手動レビュー待ち）

## テスト計画

- [ ] 次回のDependabot更新で動作確認
- [ ] パッチ更新が自動マージされることを確認
- [ ] マイナー/メジャー更新が手動レビュー待ちになることを確認

## 関連ファイル

- `.github/workflows/dependabot-auto-merge.yml` (新規作成)

🤖 Generated with [Claude Code](https://claude.com/claude-code)