### PR TITLE
refactor: simplify Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - id: meta


### PR DESCRIPTION
## Summary
- Replace complex `workflow_run`-based approach with simpler `pull_request` trigger
- Use `--auto` flag to let GitHub handle merge timing after CI passes
- Remove custom metadata parsing logic in favor of `dependabot/fetch-metadata` action

## Why
The previous implementation using `workflow_run` trigger caused `dependabot/fetch-metadata` to fail because it requires the `pull_request` event context. This simpler approach:
- Works correctly with `dependabot/fetch-metadata`
- Relies on GitHub's native auto-merge feature (requires "Allow auto-merge" enabled in repo settings)
- Is easier to maintain and debug

## Test plan
- [ ] Verify workflow triggers on Dependabot PRs
- [ ] Confirm patch version updates are auto-merged after CI passes
- [ ] Confirm non-patch updates are not auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)